### PR TITLE
難易度変更時、存在しない難易度を跨ごうとしても出来ない の修正

### DIFF
--- a/kshootmania/src/Scenes/Select/SelectDifficultyMenu.cpp
+++ b/kshootmania/src/Scenes/Select/SelectDifficultyMenu.cpp
@@ -58,6 +58,7 @@ void SelectDifficultyMenu::update()
 
 	// カーソルが存在しない難易度に変更された場合は、他の難易度への変更を試みる
 	int32 newCursor = cursorPrev;
+	int32 newDeltaCursor = 0;
 	if (deltaCursor > 0)
 	{
 		for (int idx = cursor + 1; idx < kNumDifficulties; ++idx)
@@ -65,6 +66,7 @@ void SelectDifficultyMenu::update()
 			if (menuItem.chartInfoPtr(idx) != nullptr)
 			{
 				newCursor = idx;
+				newDeltaCursor = deltaCursor;
 				break;
 			}
 		}
@@ -76,11 +78,14 @@ void SelectDifficultyMenu::update()
 			if (menuItem.chartInfoPtr(idx) != nullptr)
 			{
 				newCursor = idx;
+				newDeltaCursor = deltaCursor;
 				break;
 			}
 		}
 	}
 	m_menu.setCursor(newCursor);
+	m_menu.setDeltaCursor(newDeltaCursor);
+
 }
 
 int32 SelectDifficultyMenu::cursor() const

--- a/kshootmania/src/UI/LinearMenu.hpp
+++ b/kshootmania/src/UI/LinearMenu.hpp
@@ -65,6 +65,12 @@ public:
 	template <typename T>
 	void setCursor(T value);
 
+	/// @brief デルタカーソルの値を設定
+	/// @tparam T enumをキャストなしで指定するためのテンプレートパラメータ(指定不要)
+	/// @param value デルタカーソルの値
+	template <typename T>
+	void setDeltaCursor(T value);
+
 	/// @brief 更新(毎フレーム呼ぶ。入力を反映したくないときは呼ばないようにすればOK)
 	void update();
 
@@ -144,8 +150,12 @@ void LinearMenu::setCursor(T value)
 		}
 	}
 	m_cursor = Clamp(cursor, m_cursorMin, m_cursorMax);
+}
 
-	m_deltaCursor = 0;
+template<typename T>
+void LinearMenu::setDeltaCursor(T value)
+{
+	m_deltaCursor = static_cast<int32>(value);
 }
 
 template<typename T>


### PR DESCRIPTION
Issue #85 の対応

- 同じ難易度で選択SEが鳴る(動画だとEXで選択SEが2回なる)\
https://github.com/user-attachments/assets/c05ab5b5-f190-45a1-a5a0-9ce883825358

